### PR TITLE
Memoize unknown devices in device cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ class IoTAgent {
      */
     this.consumers = {};
 
-    this.ttl = 1 * 60 * 1000;
+    this.ttl = 1 * 60 * 1000; // a minute
     this.cache = new Cache({'ttl': this.ttl});
     this.cacheCleaner = setInterval(() => {
       const before = this.cache.length();
@@ -225,6 +225,11 @@ class IoTAgent {
       const key = this.getCacheKey(tenant, deviceid);
       const cached = this.cache.get(key);
       if (cached) {
+        // cache optimization - avoid triggering device query if device is known to be invalid
+        if (cached.hasOwnProperty('invalid') && (cached.invalid == true)) {
+          return reject(new UnknownDeviceError());
+        }
+
         // cache is to work as an LRU cache
         this.cache.set(key, cached, this.ttl);
         return resolve(cached);
@@ -239,6 +244,13 @@ class IoTAgent {
         this.cache.set(key, response.data, this.ttl);
         resolve(response.data);
       }).catch((error) => {
+        if (error.response.status == 404) {
+          // make device "invalid" for 5 minutes.
+          // Notice that if user creates a matching device within the "invalid" time, the device
+          // is updated regardless of its validity state.
+          this.cache.set(key, {invalid: true}, 5 * 60 * 1000);
+          return reject(new UnknownDeviceError());
+        }
         reject(error);
       })
     })


### PR DESCRIPTION
Remote publishing of information can be used to adversely affect dojot, by requiring the iotagent that process the (poorly) crafted message (or connection) to requisition device-manager for the unknown device for each message received. That could be used to perform a DoS attack on the platform.

This PR mitigates such attacks by limiting the surface of the attack to the iotagent itself, through the memoization of unknown devices by agents.

Notice that iotagents written without this library may still suffer from the vulnerability, thus device-manager still needs to be hardened anyways.