### PR TITLE
Fixes initialization with unavailable auth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,8 +97,8 @@ class IoTAgent {
   /**
    * Initialize all required kafka listeners and producers
    */
-  init() {
-    this.initConsumer();
+  init(retry) {
+    this.initConsumer(retry);
     this.initProducer();
   }
 
@@ -106,7 +106,7 @@ class IoTAgent {
    * Initialize iotagent kafka consumers (for tenant and device events)
    * @return {[undefined]}
    */
-  initConsumer() {
+  initConsumer(retry=true) {
     let consumer = new kafka.Consumer('internal', TENANCY_MANAGER_DEFAULTS.subject, true);
 
     consumer.on('message', (data) => {
@@ -122,19 +122,26 @@ class IoTAgent {
     });
 
     consumer.on('connect', () => {
+
+      function existing_bootstrap(agent) {
+        agent.listTenants().then((tenants) => {
+          for (let t of tenants) {
+            agent.bootstrapTenant(t);
+          }
+
+          console.log('[iota] Tenancy context management initialized');
+          agent.consumers['tenancy'] = true;
+        }).catch((error) => {
+          const message = "Failed to acquire existing tenancy contexts."
+          console.error(`[iota] ${message} ${retry ? "Retrying." : ""}`);
+          if (retry)
+            setTimeout(() => {existing_bootstrap(agent)}, 2500);
+        })
+      }
+
       if (!this.consumers.hasOwnProperty('tenancy')){
         // console.log('got connect event - tenancy');
-        this.listTenants().then((tenants) => {
-          for (let t of tenants) {
-            this.bootstrapTenant(t);
-          }
-        }).catch((error) => {
-          const message = "Failed to acquire existing tenancy contexts"
-          console.error("[iota] %s\n", message, error);
-          throw new InitializationError(message);
-        })
-        console.log('[iota] Tenancy context management initialized');
-        this.consumers['tenancy'] = true;
+        existing_bootstrap(this);
       } else {
         console.log('[iota:kafka] Tenancy subscription rebalanced')
       }

--- a/lib/kafka.js
+++ b/lib/kafka.js
@@ -146,6 +146,8 @@ class Producer {
       this.producer.send([message], (err, result) => {
         if (err) {
           console.error("[iota:kafka] Failed to publish data", err);
+          this.producer.close();
+          this.initProducer();
         }
       });
     }).catch((error) => {


### PR DESCRIPTION
Allows nodejs iotagents to be initialized whenever `auth` service becomes available, as opposed to forcefully killing the process.

This is connected to dojot/iotagent-mosca#7
This is connected to dojot/dojot#418