### PR TITLE
feat: adding 'on' function, just like Messenger from dojot.module

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,5 +10,6 @@ declare module 'dojot-iotagent' {
 
     setOnline(deviceid: string, tenant:string, expires:Date): void;
     setOffline(deviceid: string, tenant:string): void;
+    on(subject: string, event: string, callback: (tenant: string, data: any) => void): void;
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,17 @@ class IoTAgent {
   }
 
   /**
+   * Subscribes to an event from a subject. 
+   * @param {string} subject The subject
+   * @param {string} event The event
+   * @param {function} callback The callback to be executed. It should have
+   * two parameters, the tenant (a string) and data (a JSON).
+   */
+  on(subject, event, callback) {
+    this.messenger.on(subject, event, callback)
+  }
+
+  /**
    * Given a device id and its associated tenant, retrieve its full configuration.
    *
    * @param  {[string]} deviceid        Device id of the device which configuration is to be retrieved


### PR DESCRIPTION
This PR adds a 'on' method that only redirects all subscriptions to Messenger class from dojot.module. That way, a component might add a subscription to 'iotagent.device'.