### PR TITLE
fix: fixing attribute name for DeviceManager and Auth URLs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ class IoTAgent {
 
   getTenants() {
     logger.debug(`Retrieving tenants...`, TAG);
-    var ret = dojotModule.Auth.getTenants(dojotConfig.auth.host);
+    var ret = dojotModule.Auth.getTenants(dojotConfig.auth.url);
     logger.debug(`... tenants retrieval was initiated.`, TAG);
     return ret;
   }
@@ -98,8 +98,8 @@ class IoTAgent {
     return Promise
       .resolve()
       .then(() => {
-        logger.info(`Getting device from ${config.deviceManager.host}/device/${deviceid}`, TAG);
-        let url = `${config.deviceManager.host}/device/${deviceid}`;
+        logger.info(`Getting device from ${config.deviceManager.url}/device/${deviceid}`, TAG);
+        let url = `${config.deviceManager.url}/device/${deviceid}`;
         let headers = { authorization: `Bearer ${dojotModule.Auth.getManagementToken(tenant)}` };
         let method = "get";
         logger.info(`Parameters are: url: ${url}, headers: ${util.inspect(headers, { depth: null})}, method: ${method}, TAG`)


### PR DESCRIPTION
As dojot-module version beta.1 sets in its configuration file, all hosts are defined by `url` attributes, such as:

```javascript
databroker: {
  url: process.env.DATA_BROKER_URL || "http://data-broker",
  timeoutSleep: 2,
  connectionRetries: 5,
},
auth: {
  url: process.env.AUTH_URL || "http://auth:5000",
  timeoutSleep: 5,
  connectionRetries: 5,
},
deviceManager: {
  url: process.env.DEVICE_MANAGER_URL || "http://device-manager:5000",
  timeoutSleep: 5,
  connectionRetries: 3,
}
```

This PR changes that in iotagent-nodejs.