### PR TITLE
Update version of library dojot-module-nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/iotagent-nodejs",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,15 +25,15 @@
       }
     },
     "@dojot/dojot-module": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dojot/dojot-module/-/dojot-module-0.1.1.tgz",
-      "integrity": "sha512-Fl3xs1485cehvAwfXJE8GRAavhtN9/ETEKREBOxJ4QnEs8ooeT2cDe28WAUNSEX1ID9ix3zCPJH05fd8xQJMog==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@dojot/dojot-module/-/dojot-module-0.1.2.tgz",
+      "integrity": "sha512-KwyWdFpMNoEthzGDiJqfeG4aUNVnutaAwBJYbo+bcLmyJBsdFi+cPwmHx97gDmxL40EITklReDW4XJDp4VZzOg==",
       "requires": {
         "@dojot/dojot-module-logger": "^0.1.0",
         "axios": "^0.18.0",
         "express": "^4.16.3",
         "moment": "^2.22.2",
-        "node-rdkafka": "2.5.1",
+        "node-rdkafka": "2.9.1",
         "uuid": "^3.3.2"
       },
       "dependencies": {
@@ -662,12 +662,12 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-rdkafka": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.5.1.tgz",
-      "integrity": "sha512-tC7LeyshdZEds+nx0RicLn9Cam0ahpGIDNY+QAD82K/UpD2rAMIM4K/Z8NUnlnvCaLukA7229agSMogG23XcTA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
+      "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
       "requires": {
         "bindings": "^1.3.1",
-        "nan": "^2.11.1"
+        "nan": "^2.14.0"
       }
     },
     "nopt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/iotagent-nodejs",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Base iotagent functionality for dojot",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -42,7 +42,7 @@
     }
   ],
   "dependencies": {
-    "@dojot/dojot-module": "^0.1.1",
+    "@dojot/dojot-module": "^0.1.2",
     "@dojot/dojot-module-logger": "^0.1.0",
     "axios": "^0.17.1",
     "js-base64": "^2.3.2",


### PR DESCRIPTION
The supported Node.js version is now v12 and no longer v10.